### PR TITLE
Added centos-6.4 data to .kitchen.yml and update Cheffile to point to re...

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -2,7 +2,7 @@
 driver:
   name: vagrant
   customize:
-    memory: 1024
+    memory: 512
 
 provisioner:
   name: chef_zero
@@ -11,6 +11,14 @@ platforms:
   - name: ubuntu-12.04
     run_list:
       - recipe[apt]
+      - recipe[zookeeperd::server]
+      - recipe[kafka]
+    attributes:
+      zookeeperd:
+        cluster:
+          auto_discovery: false
+  - name: centos-6.4
+    run_list:
       - recipe[zookeeperd::server]
       - recipe[kafka]
     attributes:

--- a/Cheffile
+++ b/Cheffile
@@ -4,3 +4,4 @@ site "http://community.opscode.com/api/v1"
 
 cookbook "kafka", path: "."
 cookbook "apt"
+cookbook "zookeeperd", git: "https://github.com/aimtheory/zookeeperd.git", :ref => "redhat"


### PR DESCRIPTION
This cookbook, without any changes, works on Centos 6.4. KitchenCI ran Chef for both Kafka 0.7 and 0.8 with no errors and 3 tests passed. Only changes to the repo are .kitchen.yml additions for centos-6.4 and a reference in Cheffile to as-yet-unmerged redhat branch of zookeeperd.
