### PR TITLE
make sure permissions are set after build

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -34,6 +34,7 @@ else
   build_commands << "./sbt assembly-package-dependency" unless kafka_is_below_07?
 end
 build_commands << "cp -R . #{base_dir}"
+build_commands << "chown -R #{node[:kafka][:user]}:#{node[:kafka][:group]} #{base_dir}"
 node.default[:kafka][:build_commands] = build_commands
 
 group node[:kafka][:group]
@@ -73,6 +74,8 @@ end
 
 link "#{node[:kafka][:install_dir]}/kafka" do
   to base_dir
+  owner node[:kafka][:user]
+  group node[:kafka][:group]
 end
 
 runit_service "kafka" do


### PR DESCRIPTION
Previously the build commands changed the directory back to root:root after building and copying. This meant that when kafka started it was unable to create a logs file in the install directory. Kafka would start but it would fail to really be healthy because it wasn't able to write/create that directory. Also, the sym-linked directory would also be root:root compounding the issue. This makes sure that the kafka install directory is able to be managed by the kafka user.
