### PR TITLE
configure jmx_port option in kafka-server-start …

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,7 +13,7 @@ default[:kafka][:group] = "kafka"
 default[:kafka][:shell] = "/bin/false"
 default[:kafka][:build_commands] = []
 default[:kafka][:jmx_opts] = "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false  -Dcom.sun.management.jmxremote.ssl=false "
-default[:kafka][:jmx_port] = ""
+default[:kafka][:jmx_port] = nil
 
 default[:kafka][:auto_discovery] = true
 

--- a/templates/default/kafka-run-class-8.1.erb
+++ b/templates/default/kafka-run-class-8.1.erb
@@ -79,8 +79,6 @@ if [ -z "$KAFKA_JMX_OPTS" ]; then
   KAFKA_JMX_OPTS="<%= @jmx_opts %>"
 fi
 
-# JMX port to use
-JMX_PORT="<%= @jmx_port %>"
 if [  $JMX_PORT ]; then
   KAFKA_JMX_OPTS="$KAFKA_JMX_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT "
 fi

--- a/templates/default/kafka-run-class-8.2.erb
+++ b/templates/default/kafka-run-class-8.2.erb
@@ -82,8 +82,6 @@ if [ -z "$KAFKA_JMX_OPTS" ]; then
   KAFKA_JMX_OPTS="<%= @jmx_opts %>"
 fi
 
-# JMX port to use
-JMX_PORT="<%= @jmx_port %>"
 if [  $JMX_PORT ]; then
   KAFKA_JMX_OPTS="$KAFKA_JMX_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT "
 fi

--- a/templates/default/kafka-server-start-8.1.erb
+++ b/templates/default/kafka-server-start-8.1.erb
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+export JMX_PORT=<%= @jmx_port %>
+
+if [ $# -lt 1 ];
+then
+        echo "USAGE: $0 [-daemon] server.properties"
+        exit 1
+fi
+base_dir=$(dirname $0)
+
+if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
+    export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/log4j.properties"
+fi
+
+if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
+    export KAFKA_HEAP_OPTS="-Xmx1G -Xms1G"
+fi
+
+EXTRA_ARGS="-name kafkaServer -loggc"
+
+COMMAND=$1
+case $COMMAND in
+  -daemon)
+    EXTRA_ARGS="-daemon "$EXTRA_ARGS
+    shift
+    ;;
+  *)
+    ;;
+esac
+
+exec $base_dir/kafka-run-class.sh $EXTRA_ARGS kafka.Kafka $@

--- a/templates/default/kafka-server-start-8.2.erb
+++ b/templates/default/kafka-server-start-8.2.erb
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+export JMX_PORT=<%= @jmx_port %>
+
+if [ $# -lt 1 ];
+then
+        echo "USAGE: $0 [-daemon] server.properties"
+        exit 1
+fi
+base_dir=$(dirname $0)
+
+if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
+    export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/log4j.properties"
+fi
+
+if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
+    export KAFKA_HEAP_OPTS="-Xmx1G -Xms1G"
+fi
+
+EXTRA_ARGS="-name kafkaServer -loggc"
+
+COMMAND=$1
+case $COMMAND in
+  -daemon)
+    EXTRA_ARGS="-daemon "$EXTRA_ARGS
+    shift
+    ;;
+  *)
+    ;;
+esac
+
+exec $base_dir/kafka-run-class.sh $EXTRA_ARGS kafka.Kafka $@


### PR DESCRIPTION
* configure jmx_port option in kafka-server-start 
  * default behavior will not use template unless jmx_port is set.
* only use jmx_opts for kafka-run-class